### PR TITLE
feat: inject link tag of cdn css if necessary

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,23 @@
 'use strict';
 
 var katex = require('katex');
+var util = require('hexo-util');
 var cheerio;
 
 hexo.extend.filter.register('after_post_render', function(data){
   var content = data.content;
+  var linkTag = '';
 
   if (!cheerio) cheerio = require('cheerio');
 
   var $ = cheerio.load(data.content, {decodeEntities: false});
+
+  if ($('.math').length > 0){
+    linkTag = util.htmlTag('link', {
+      rel: 'stylesheet',
+      href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css'
+    });
+  }
 
   $('.math.inline').each(function(){
     var html = katex.renderToString($(this).text());
@@ -20,5 +29,5 @@ hexo.extend.filter.register('after_post_render', function(data){
     $(this).replaceWith(html)
   });
 
-  data.content = $.html();
+  data.content = linkTag + $.html();
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "cheerio": "^0.19.0",
+    "hexo-util": "^0.6.0",
     "katex": "^0.5.1"
   }
 }


### PR DESCRIPTION
Add a new feature that injecting link tag of CDN CSS.

Inject link tag of CDN CSS per post, if you use math env in the post.
You don't use math env in some posts, the posts will be skipped.