### PR TITLE
fix: error when there is no katex config option in _config.yml

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,9 @@ hexo.extend.filter.register('after_post_render', function(data){
     $(this).replaceWith(html)
   });
 
-  if (options.css === false) {
+  if (options && options.css === false) {
     data.content = $.html();
   } else {
     data.content = linkTag + $.html();
   }
 });
-


### PR DESCRIPTION
fix: error when there is no katex config option in `_config.yml`

When there is no katex config option in `_config.yml`, an error is raised: `TypeError: Cannot read property 'css' of undefined`
So fix to check `options` is not undefined or other falsy value, before read property 'css' of `options`.