### PR TITLE
Fix katex error

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ hexo.extend.filter.register('after_post_render', function(data) {
   if ($('.math').length > 0) {
     linkTag = util.htmlTag('link', {
       rel: 'stylesheet',
-      href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css',
+      href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/katex.min.css',
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -1,40 +1,51 @@
-'use strict';
+'use strict'
 
-var katex = require('katex');
-var util = require('hexo-util');
-var cheerio;
+var katex = require('katex')
+var util = require('hexo-util')
+var cheerio
 
-hexo.extend.filter.register('after_post_render', function(data){
+hexo.extend.filter.register('after_post_render', function(data) {
   var hexo = this,
-      options = hexo.config.katex;
+    options = hexo.config.katex
 
-  var content = data.content;
-  var linkTag = '';
+  var content = data.content
+  var linkTag = ''
 
-  if (!cheerio) cheerio = require('cheerio');
+  if (!cheerio) cheerio = require('cheerio')
 
-  var $ = cheerio.load(data.content, {decodeEntities: true});
+  var $ = cheerio.load(data.content, { decodeEntities: true })
 
-  if ($('.math').length > 0){
+  if ($('.math').length > 0) {
     linkTag = util.htmlTag('link', {
       rel: 'stylesheet',
-      href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css'
-    });
+      href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css',
+    })
   }
 
-  $('.math.inline').each(function(){
-    var html = katex.renderToString($(this).text());
+  $('.math.inline').each(function() {
+    // remove unnecessary characters "\\(" and "\)"
+    var html = katex.renderToString(
+      $(this)
+        .text()
+        .slice(2, -2),
+    )
     $(this).replaceWith(html)
-  });
+  })
 
-  $('.math.display').each(function(){
-    var html = katex.renderToString($(this).text(), { displayMode: true });
+  $('.math.display').each(function() {
+    // remove unnecessary characters "\\[" and "\]"
+    var html = katex.renderToString(
+      $(this)
+        .text()
+        .slice(2, -2),
+      { displayMode: true },
+    )
     $(this).replaceWith(html)
-  });
+  })
 
   if (options && options.css === false) {
-    data.content = $.html();
+    data.content = $.html()
   } else {
-    data.content = linkTag + $.html();
+    data.content = linkTag + $.html()
   }
-});
+})

--- a/index.js
+++ b/index.js
@@ -18,7 +18,10 @@ hexo.extend.filter.register('after_post_render', function(data) {
   if ($('.math').length > 0) {
     linkTag = util.htmlTag('link', {
       rel: 'stylesheet',
-      href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/katex.min.css',
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css',
+      integrity:
+        'sha384-9tPv11A+glH/on/wEu99NVwDPwkMQESOocs/ZGXPoIiLE8MU/qkqUcZ3zzL+6DuH',
+      crossorigin: 'anonymous',
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-katex",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Use KaTeX to display math in Hexo sites.",
   "main": "index",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "hexo-util": "^0.6.0",
-    "katex": "^0.7.1"
+    "katex": "^0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "hexo-util": "^0.6.0",
-    "katex": "^0.9.0"
+    "katex": "^0.10.0-beta"
   }
 }


### PR DESCRIPTION
When I tried to create a new blog with `hexo-katex` and correct settings `hexo-renderer-pandoc`, katex gave like the following error.

```
FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/docs/troubleshooting.html
ParseError: KaTeX parse error: Expected 'EOF', got '\(' at position 1: \̲(̲a = b\)
    at new ParseError (G:\user\Documents\test-site\node_modules\katex\src\ParseError.js:53:16)
    at Parser.expect (G:\user\Documents\test-site\node_modules\katex\src\Parser.js:81:15)
    at Parser.parseInput (G:\user\Documents\test-site\node_modules\katex\src\Parser.js:125:10)
    at Parser.parse (G:\user\Documents\test-site\node_modules\katex\src\Parser.js:114:22)
    at parseTree (G:\user\Documents\test-site\node_modules\katex\src\parseTree.js:17:19)
    at Object.renderToString (G:\user\Documents\test-site\node_modules\katex\katex.js:52:16)
    at Object.<anonymous> (C:\Users\sator\Documents\test-site\node_modules\hexo-katex\index.js:26:22)
    at initialize.exports.each (G:\user\Documents\test-site\node_modules\cheerio\lib\api\traversing.js:300:24)
    at Hexo.<anonymous> (C:\Users\sator\Documents\test-site\node_modules\hexo-katex\index.js:25:21)
    at Hexo.tryCatcher (G:\user\Documents\test-site\node_modules\bluebird\js\release\util.js:16:23)
    at Hexo.<anonymous> (G:\user\Documents\test-site\node_modules\bluebird\js\release\method.js:15:34)
    at Promise.each.filter (G:\user\Documents\test-site\node_modules\hexo\lib\extend\filter.js:63:65)
    at tryCatcher (G:\user\Documents\test-site\node_modules\bluebird\js\release\util.js:16:23)
    at Object.gotValue (G:\user\Documents\test-site\node_modules\bluebird\js\release\reduce.js:155:18)
    at Object.gotAccum (G:\user\Documents\test-site\node_modules\bluebird\js\release\reduce.js:144:25)
    at Object.tryCatcher (G:\user\Documents\test-site\node_modules\bluebird\js\release\util.js:16:23)
    at Promise._settlePromiseFromHandler (G:\user\Documents\test-site\node_modules\bluebird\js\release\promise.js:512:31)
    ...
```

It seems that there are unnecessary characters `\\(`, `\)`,`\\[` and `\]` at head and tail of math strings.
Passing the wrong string to `katex.renderToString` seems to be causing the error.

So I wrote some code to remove unnecessary characters and pass to `katex.renderToString`.

I also updated a version of KaTeX to the latest.

---

hexo: v3.7.1
pandoc: v2.2.1