### PR TITLE
no longer truncating

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,29 +18,25 @@ hexo.extend.filter.register('after_post_render', function(data) {
   if ($('.math').length > 0) {
     linkTag = util.htmlTag('link', {
       rel: 'stylesheet',
-      href: 'https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css',
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css',
       integrity:
-        'sha384-9tPv11A+glH/on/wEu99NVwDPwkMQESOocs/ZGXPoIiLE8MU/qkqUcZ3zzL+6DuH',
+        'sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ',
       crossorigin: 'anonymous',
     })
   }
 
   $('.math.inline').each(function() {
-    // remove unnecessary characters "\\(" and "\)"
     var html = katex.renderToString(
       $(this)
-        .text()
-        .slice(2, -2),
+        .text(),
     )
     $(this).replaceWith(html)
   })
 
   $('.math.display').each(function() {
-    // remove unnecessary characters "\\[" and "\]"
     var html = katex.renderToString(
       $(this)
-        .text()
-        .slice(2, -2),
+        .text(),
       { displayMode: true },
     )
     $(this).replaceWith(html)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "hexo-katex",
+  "version": "0.0.10",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+    },
+    "katex": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.10.1.tgz",
+      "integrity": "sha512-iZXZ2L8pEP7HXBLAaeWkdLxnoRQ8Fdks8IuIVt01tYb+D8e0em5JYgfe6J48wXsuEr512IRCN5Kvwb9FjZH6kg==",
+      "requires": {
+        "commander": "^2.19.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-katex",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Use KaTeX to display math in Hexo sites.",
   "main": "index",
   "repository": {
@@ -23,6 +23,6 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "hexo-util": "^0.6.0",
-    "katex": "^0.10.0-beta"
+    "katex": "^0.10.1"
   }
 }


### PR DESCRIPTION
It seems truncating is no longer needed.
It works fine with `hexo-renderer-pandoc@0.2.6`.