### PR TITLE
feat: new options "macros" & "throw_on_error"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ katex:
   css: false
 ```
 
+You can define macros like that:
+
+```
+katex:
+  macros:
+    \hash: \mathop\mathrm{hash}
+```
+
 
 ## Writing
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ katex:
   css: false
 ```
 
+When KaTeX encounters an unsupported command, it will abort a rendering process. You can change the behavior by modifing `_config.yml`.
+
+```
+katex:
+  throw_on_error: false
+```
+
 You can define macros like that:
 
 ```

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ hexo.extend.filter.register('after_post_render', function(data) {
 
   $('.math.inline').each(function() {
     var html = katex.renderToString($(this).text(), {
+      throwOnError: options.throw_on_error === undefined || options.throw_on_error,
       macros: options.macros,
     })
     $(this).replaceWith(html)
@@ -34,6 +35,7 @@ hexo.extend.filter.register('after_post_render', function(data) {
 
   $('.math.display').each(function() {
     var html = katex.renderToString($(this).text(), {
+      throwOnError: options.throw_on_error === undefined || options.throw_on_error,
       macros: options.macros,
       displayMode: true,
     })

--- a/index.js
+++ b/index.js
@@ -26,19 +26,17 @@ hexo.extend.filter.register('after_post_render', function(data) {
   }
 
   $('.math.inline').each(function() {
-    var html = katex.renderToString(
-      $(this)
-        .text(),
-    )
+    var html = katex.renderToString($(this).text(), {
+      macros: options.macros,
+    })
     $(this).replaceWith(html)
   })
 
   $('.math.display').each(function() {
-    var html = katex.renderToString(
-      $(this)
-        .text(),
-      { displayMode: true },
-    )
+    var html = katex.renderToString($(this).text(), {
+      macros: options.macros,
+      displayMode: true,
+    })
     $(this).replaceWith(html)
   })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-katex",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Use KaTeX to display math in Hexo sites.",
   "main": "index",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-katex",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Use KaTeX to display math in Hexo sites.",
   "main": "index",
   "repository": {


### PR DESCRIPTION
Enabled to define macros, and change the KaTeX behavior when it encounters an error, like that:
```
katex:
  throw_on_error: false
  macros:
    \hash: \mathop\mathrm{hash}
```